### PR TITLE
Fixed all NANs when genes with all zeros. #11

### DIFF
--- a/combat.py
+++ b/combat.py
@@ -86,7 +86,7 @@ def combat(data, batch, model=None, numerical_covariates=None):
     design = design_mat(model, numerical_covariates, batch_levels)
     # remove genes with all zeros, if not, corrected dataframe will be all NAs. 
     sys.stderr.write("Preprocessing Data across genes.\n")
-    data = data[data.sum(axis=1) > 0 ]
+    data = data[ (data != 0).sum(axis=1) > 0 ]
 
     sys.stderr.write("Standardizing Data across genes.\n")
     B_hat = np.dot(np.dot(la.inv(np.dot(design.T, design)), design.T), data.T)

--- a/combat.py
+++ b/combat.py
@@ -84,6 +84,9 @@ def combat(data, batch, model=None, numerical_covariates=None):
             for c in numerical_covariates if not c in drop_cols]
 
     design = design_mat(model, numerical_covariates, batch_levels)
+    # remove genes with all zeros, if not, corrected dataframe will be all NAs. 
+    sys.stderr.write("Preprocessing Data across genes.\n")
+    data = data[data.sum(axis=1) > 0 ]
 
     sys.stderr.write("Standardizing Data across genes.\n")
     B_hat = np.dot(np.dot(la.inv(np.dot(design.T, design)), design.T), data.T)


### PR DESCRIPTION
I have the same issue that " DataFrame contains rows which are entirely zero the result returned by combat() will contain all NaNs".
May be it's a good choice to drop these entirely zeros, because all zeros could no be corrected further.
Hope this is usefull